### PR TITLE
Feature/performance optimisations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,28 @@ jobs:
         run: pixi run submodule-update
 
       - name: Configure project
+        if: matrix.os != 'ubuntu-latest'
         run: pixi run configure
 
       - name: Build project
+        if: matrix.os != 'ubuntu-latest'
         run: pixi run build
 
+      - name: Configure project
+        if: matrix.os == 'ubuntu-latest'
+        run: pixi run configure_debug
+
+      - name: Build project
+        if: matrix.os == 'ubuntu-latest'
+        run: pixi run build_debug
+        
       - name: Run C++ tests
+        if: matrix.os != 'ubuntu-latest'
         run: pixi run test
+
+      - name: Run C++ tests
+        if: matrix.os == 'ubuntu-latest'
+        run: pixi run test_debug
 
       - name: Generate coverage report
         if: matrix.os == 'self-hosted'

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,11 +23,14 @@ valgrind = "*"
 
 [tasks]
 clean = "rm -fr build && rm -fr build_cov"
+configure_debug = "cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug"
 configure = "cmake -S . -B build -G Ninja"
 configure_coverage = "cmake -S . -B build_cov -DBUILD_DOC_DOXYGEN=ON -DENABLE_COVERAGE=ON  -DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
 build = {cmd="cmake --build build --parallel", depends-on = "configure"}
+build_debug = {cmd="cmake --build build --parallel", depends-on = "configure_debug"}
 build_coverage = {cmd="cmake --build build_cov -j8", depends-on = "configure_coverage"}
 test = {cmd="ctest --test-dir build --output-on-failure", depends-on = "build"}
+test_debug = {cmd="ctest --test-dir build --output-on-failure", depends-on = "build_debug"}
 test_regression = { cmd = "scripts/tests/test_run.sh", depends-on = ["build"] }
 test_align = { cmd = "scripts/tests/test_align.sh", depends-on = ["build"] }
 benchmark = { cmd = "scripts/tests/benchmark_run.sh", depends-on = ["build"] }

--- a/src/igor/Core/Aligner.cpp
+++ b/src/igor/Core/Aligner.cpp
@@ -859,7 +859,7 @@ unordered_map<int, vector<Alignment_data>> read_alignments_seq_csv(const string 
                 }
             }
         }
-        if (!allow_in_dels & (!insertions.empty() | !deletions.empty())) {
+        if (!allow_in_dels && (!insertions.empty() || !deletions.empty())) {
             continue;
         }
 
@@ -1060,7 +1060,7 @@ Int_Str nt2int(const string &nt_sequence)
 bool comp_nt_int(const int &nt_1, const int &nt_2)
 {
     if (nt_1 != nt_2) {
-        if ((nt_1 < 4) & (nt_2 < 4)) {
+        if ((nt_1 < 4) && (nt_2 < 4)) {
             return false;
         } else {
             switch (nt_1) {
@@ -1332,7 +1332,7 @@ void Aligner::sw_align_common(const Int_Str &int_data_sequence, const Int_Str &i
     int subs_score =
             score_matrix(i - 1, j - 1) + substitution_matrix(int_data_sequence.at(i), int_genomic_sequence.at(j));
 
-    if ((subs_score >= data_gap_score) & (subs_score >= genomic_gap_score) & ((subs_score > 0) | (!local_align))) {
+    if ((subs_score >= data_gap_score) && (subs_score >= genomic_gap_score) && ((!local_align) || (subs_score > 0)) ) {
         score_matrix(i, j) = subs_score;
         row_memory_matrix(i, j) = 1;
         col_memory_matrix(i, j) = 1;
@@ -1345,14 +1345,14 @@ void Aligner::sw_align_common(const Int_Str &int_data_sequence, const Int_Str &i
             alignment_numb_tracker(i, j) = alignment_numb_tracker(i - 1, j - 1);
         }
 
-    } else if ((data_gap_score >= genomic_gap_score) & ((data_gap_score > 0) | (!local_align))) {
+    } else if ((data_gap_score >= genomic_gap_score) && ((!local_align) || (data_gap_score > 0))) {
         //This is in favor of deletions in the sequenced read instead of insertion.
         //No real rational behind it just to avoid undefined behavior of the aligner
         score_matrix(i, j) = data_gap_score;
         row_memory_matrix(i, j) = 1;
         col_memory_matrix(i, j) = 0;
         alignment_numb_tracker(i, j) = alignment_numb_tracker(i - 1, j);
-    } else if ((genomic_gap_score > 0) | (!local_align)) {
+    } else if ((!local_align) || (genomic_gap_score > 0)) {
         score_matrix(i, j) = genomic_gap_score;
         row_memory_matrix(i, j) = 0;
         col_memory_matrix(i, j) = 1;
@@ -1487,7 +1487,7 @@ list<pair<int, Alignment_data>> Aligner::sw_align(const Int_Str &int_data_sequen
             int i = 1;
             int j = 1;
 
-            while ((i != explored_row_coord) & (j != explored_col_coord)) {
+            while ((i != explored_row_coord) && (j != explored_col_coord)) {
                 sw_align_common(int_data_sequence_copy, int_genomic_sequence_copy, i, explored_col_coord, score_matrix,
                                 row_memory_matrix, col_memory_matrix, alignment_numb_tracker, max_score, max_row_coord,
                                 max_col_coord);
@@ -1503,7 +1503,7 @@ list<pair<int, Alignment_data>> Aligner::sw_align(const Int_Str &int_data_sequen
                             max_row_coord, max_col_coord);
         }
 
-        if ((explored_row_coord == n_rows) & (explored_col_coord == n_cols)) {
+        if ((explored_row_coord == n_rows) && (explored_col_coord == n_cols)) {
             matrix_complete = true;
         }
         if (explored_row_coord != n_rows) {
@@ -1606,7 +1606,7 @@ list<pair<int, Alignment_data>> Aligner::sw_align(const Int_Str &int_data_sequen
             int offset = flip_factor * (i - j) + flip_offset + offset_change;
 
             if ((offset >= min_offset)
-                & (offset
+                && (offset
                    <= max_offset)) { //TODO reduce computation time by truncating the alignment from the beginning?
                 //TODO change this and use incorporate_in_dels(), should probably change the list inside alignment data also to have the actual corresponding indices
                 //TODO return the actual inserted/deleted sequences in the alignment data??
@@ -1678,7 +1678,7 @@ list<pair<int, Alignment_data>> Aligner::sw_align(const Int_Str &int_data_sequen
             }
         }
     }
-    if (best_only & (seq_alignments_results.size() > 1)) {
+    if (best_only && (seq_alignments_results.size() > 1)) {
         for (list<pair<int, Alignment_data>>::iterator align = seq_alignments_results.begin();
              align != seq_alignments_results.end(); ++align) {
             if ((*align).first < max_align_score) {

--- a/src/igor/Core/Deletion.cpp
+++ b/src/igor/Core/Deletion.cpp
@@ -293,7 +293,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                 //Positive or negative deletion (palindroms) mechanism
                 if ((*iter).value_int >= 0) {
                     //Delete the end of the V-gene (3' end)
-                    new_str = previous_str.substr(0, previous_str.size() - (*iter).value_int);
+                    previous_str.substr(new_str, 0, previous_str.size() - (*iter).value_int);
 
                     //Update the mismatch list given the deletions
                     if (!v_mismatch_list.empty()) {
@@ -327,7 +327,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                         if ((-(*iter).value_int) <= (int)previous_str.size()) {
                             //Copy the last nucleotides
                             //cout<<"# p nucl: "<<(-(*iter).second.value_int)<<endl;
-                            tmp_str = previous_str.substr(previous_str.size() + (*iter).value_int, string::npos);
+                            previous_str.substr(tmp_str, previous_str.size() + (*iter).value_int, string::npos);
                             //cout<<"tmp_str: "<<tmp_str<<endl;
                             //Reverse them
                             //TODO revise this (perhaps not a good idea to perform these operations every time)
@@ -536,7 +536,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                         //////////////////////////////////////////////////////////////////////////
 
                         //Delete the beginning of the D-gene (5' end)
-                        new_str = previous_str.substr((*iter).value_int, string::npos);
+                        previous_str.substr(new_str, (*iter).value_int, string::npos);
 
                         //Update the mismatches given the number of deleted nucleotides
                         //Discard irrelevant mismatches (assuming the vector of mismatches is ordered) given the number of deletions
@@ -567,7 +567,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                             if ((-(*iter).value_int) <= (int)previous_str.size()) {
 
                                 //Copy the first nucleotides
-                                tmp_str = previous_str.substr(0, -(*iter).value_int);
+                                previous_str.substr(tmp_str, 0, -(*iter).value_int);
 
                                 //Reverse them
                                 reverse(tmp_str.begin(), tmp_str.end());
@@ -770,7 +770,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                         //////////////////////////////////////////////////////////////////////////
 
                         //Delete the end of the D-gene (3'end)
-                        new_str = previous_str.substr(0, previous_str.size() - (*iter).value_int);
+                        previous_str.substr(new_str, 0, previous_str.size() - (*iter).value_int);
 
                         //Update mismatches list given the number of deletions
                         //Discard irrelevant mismatches (assuming the vector of mismatches is ordered) given the number of deletions
@@ -806,7 +806,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                             if ((-(*iter).value_int) <= (int)previous_str.size()) {
                                 //Copy the last nucleotides
 
-                                tmp_str = previous_str.substr(previous_str.size() + (*iter).value_int, string::npos);
+                                previous_str.substr(tmp_str, previous_str.size() + (*iter).value_int, string::npos);
 
                                 //Reverse them
                                 reverse(tmp_str.begin(), tmp_str.end());
@@ -1049,7 +1049,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
                 //Positive or negative deletion (palindroms) mechanism
                 if ((*iter).value_int >= 0) {
                     //Delete the beginning of the J-gene (5' end)
-                    new_str = previous_str.substr((*iter).value_int);
+                    previous_str.substr(new_str, (*iter).value_int);
 
                     //Update mismatch list given the number of deletions
                     //Discard irrelevant mismatches (assuming the vector of mismatches is ordered) given the number of deletions
@@ -1079,7 +1079,7 @@ void Deletion::iterate(double &scenario_proba, Downstream_scenario_proba_bound_m
 
                         //Copy the first nucleotides
                         //cout<<"# p nucl: "<<(-(*iter).second.value_int)<<endl;
-                        tmp_str = previous_str.substr(0, -(*iter).value_int);
+                        previous_str.substr(tmp_str, 0, -(*iter).value_int);
                         //cout<<"tmp_str: "<<tmp_str<<endl;
                         //Reverse them
                         reverse(tmp_str.begin(), tmp_str.end());

--- a/src/igor/Core/Genechoice.cpp
+++ b/src/igor/Core/Genechoice.cpp
@@ -619,7 +619,7 @@ void Gene_choice::iterate(
                         //Get mismatches between D gene and sequence
                         no_d_mismatches.clear();
                         for (int i = 0; i != d_size; ++i) {
-                            if (((d_5_off + i) >= 0) & (d_5_off + i) < int_sequence.size()) {
+                            if (((d_5_off + i) >= 0) && (d_5_off + i) < int_sequence.size()) {
                                 if (gene_seq[i] != int_sequence[d_5_off + i]) {
                                     no_d_mismatches.push_back(d_5_off + i);
                                 }
@@ -728,7 +728,7 @@ void Gene_choice::iterate(
                         //Get mismatches between D gene and sequence at the 5' most position
                         no_d_mismatches.clear();
                         for (int i = 0; i != d_size; ++i) {
-                            if (((d_5_off + i) >= 0) & (d_5_off + i) < int_sequence.size()) {
+                            if (((d_5_off + i) >= 0) && (d_5_off + i) < int_sequence.size()) {
                                 if (gene_seq[i] != int_sequence[d_5_off + i]) {
                                     no_d_mismatches.push_back(d_5_off + i);
                                 }

--- a/src/igor/Core/IntStr.cpp
+++ b/src/igor/Core/IntStr.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <igor/Core/IntStr.h>
-#include <algorithm>
 
 using namespace std;
 
@@ -68,17 +67,29 @@ Int_Str Int_Str::operator+(const Int_Str &other) const
 
 void Int_Str::substr(Int_Str &new_int_str, size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
 {
-    auto begin = this->begin() + pos;
-    auto end = this->end();
-    auto last = (len == npos) ? end : std::min(begin + len, end);
+    Int_Str::const_iterator begin = this->begin() + pos;
+    Int_Str::const_iterator last;
+    if (len == npos) {
+        last = this->end();
+    } else if (pos + len >= this->size()) {
+        last = this->end();
+    } else {
+        last = begin + len;
+    }
     new_int_str.assign(begin, last);
 }
 
 Int_Str Int_Str::substr(size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
 {
-    auto begin = this->begin() + pos;
-    auto end = this->end();
-    auto last = (len == npos) ? end : std::min(begin + len, end);
+    Int_Str::const_iterator begin = this->begin() + pos;
+    Int_Str::const_iterator last;
+    if (len == npos) {
+        last = this->end();
+    } else if (pos + len >= this->size()) {
+        last = this->end();
+    } else {
+        last = begin + len;
+    }
     Int_Str new_int_str;
     new_int_str.assign(begin, last);
     return new_int_str;
@@ -86,9 +97,15 @@ Int_Str Int_Str::substr(size_t pos /*= 0*/, size_t len /*= 99999999999999*/) con
 
 Int_Str &Int_Str::erase(size_t pos, size_t len)
 {
-    auto begin = this->begin() + pos;
-    auto end = this->end();
-    auto last = (len == npos) ? end : std::min(begin + len, end);
+    Int_Str::iterator begin = this->begin() + pos;
+    Int_Str::iterator last;
+    if (len == npos) {
+        last = this->end();
+    } else if (pos + len >= this->size()) {
+        last = this->end();
+    } else {
+        last = begin + len;
+    }
     this->erase(begin, last);
     return *this;
 }

--- a/src/igor/Core/IntStr.cpp
+++ b/src/igor/Core/IntStr.cpp
@@ -65,6 +65,20 @@ Int_Str Int_Str::operator+(const Int_Str &other) const
     return new_int_str;
 }
 
+void Int_Str::substr(Int_Str &new_int_str, size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
+{
+    Int_Str::const_iterator begin = this->begin() + pos;
+    Int_Str::const_iterator last;
+    if (len == npos) {
+        last = this->end();
+    } else if (pos + len >= this->size()) {
+        last = this->end();
+    } else {
+        last = begin + len;
+    }
+    new_int_str.assign(begin, last);
+}
+
 Int_Str Int_Str::substr(size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
 {
     Int_Str::const_iterator begin = this->begin() + pos;

--- a/src/igor/Core/IntStr.cpp
+++ b/src/igor/Core/IntStr.cpp
@@ -25,6 +25,7 @@
  */
 
 #include <igor/Core/IntStr.h>
+#include <algorithm>
 
 using namespace std;
 
@@ -67,29 +68,17 @@ Int_Str Int_Str::operator+(const Int_Str &other) const
 
 void Int_Str::substr(Int_Str &new_int_str, size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
 {
-    Int_Str::const_iterator begin = this->begin() + pos;
-    Int_Str::const_iterator last;
-    if (len == npos) {
-        last = this->end();
-    } else if (pos + len >= this->size()) {
-        last = this->end();
-    } else {
-        last = begin + len;
-    }
+    auto begin = this->begin() + pos;
+    auto end = this->end();
+    auto last = (len == npos) ? end : std::min(begin + len, end);
     new_int_str.assign(begin, last);
 }
 
 Int_Str Int_Str::substr(size_t pos /*= 0*/, size_t len /*= 99999999999999*/) const
 {
-    Int_Str::const_iterator begin = this->begin() + pos;
-    Int_Str::const_iterator last;
-    if (len == npos) {
-        last = this->end();
-    } else if (pos + len >= this->size()) {
-        last = this->end();
-    } else {
-        last = begin + len;
-    }
+    auto begin = this->begin() + pos;
+    auto end = this->end();
+    auto last = (len == npos) ? end : std::min(begin + len, end);
     Int_Str new_int_str;
     new_int_str.assign(begin, last);
     return new_int_str;
@@ -97,15 +86,9 @@ Int_Str Int_Str::substr(size_t pos /*= 0*/, size_t len /*= 99999999999999*/) con
 
 Int_Str &Int_Str::erase(size_t pos, size_t len)
 {
-    Int_Str::iterator begin = this->begin() + pos;
-    Int_Str::iterator last;
-    if (len == npos) {
-        last = this->end();
-    } else if (pos + len >= this->size()) {
-        last = this->end();
-    } else {
-        last = begin + len;
-    }
+    auto begin = this->begin() + pos;
+    auto end = this->end();
+    auto last = (len == npos) ? end : std::min(begin + len, end);
     this->erase(begin, last);
     return *this;
 }

--- a/src/igor/Core/IntStr.h
+++ b/src/igor/Core/IntStr.h
@@ -49,6 +49,7 @@ public:
     Int_Str operator+(int) const;
 
     Int_Str substr(std::size_t pos = 0, std::size_t len = npos) const; //TODO correct this with aproper value
+    void substr(Int_Str &, std::size_t pos = 0, std::size_t len = npos) const; //TODO correct this with aproper value
 
     using std::vector<int>::erase;
     Int_Str &erase(std::size_t pos, std::size_t len);

--- a/src/igor/Core/Singleerrorrate.cpp
+++ b/src/igor/Core/Singleerrorrate.cpp
@@ -195,7 +195,7 @@ queue<int> Single_error_rate::generate_errors(string &generated_seq, mt19937_64 
                     (*iter) = 'T';
                 }
 
-            } else if ((*iter == 'T')) {
+            } else if ((*iter) == 'T') {
                 if (rand_trans <= 1.0 / 3.0) {
                     (*iter) = 'A';
                 } else if (rand_trans >= 2.0 / 3.0) {

--- a/src/igor/Core/Utils.h
+++ b/src/igor/Core/Utils.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include <cassert>
+
 #include <fstream>
 #include <vector>
 #include <string>
@@ -222,25 +224,13 @@ public:
 
     T &operator()(const int &i, const int &j)
     {
-        if ((i > rows - 1) || (j > cols - 1)) {
-            throw std::length_error("Cannot access indices [" + std::to_string(i) + "," + std::to_string(j)
-                                    + "] with matrix dimensions [" + std::to_string(rows) + "," + std::to_string(cols)
-                                    + "]");
-            std::cout << "out_of range matrix coordinates: " << rows << "<" << i << " or " << cols << "<" << j
-                      << std::endl;
-        }
+        assert((i > rows - 1) || (j > cols - 1));
         return array_p[i + rows * j];
     }
 
     const T &operator()(const int &i, const int &j) const
     {
-        if ((i > rows - 1) || (j > cols - 1)) {
-            throw std::length_error("Cannot access indices [" + std::to_string(i) + "," + std::to_string(j)
-                                    + "] with matrix dimensions [" + std::to_string(rows) + "," + std::to_string(cols)
-                                    + "]");
-            std::cout << "out_of range matrix coordinates: " << rows << "<" << i << " or " << cols << "<" << j
-                      << std::endl;
-        }
+        assert((i > rows - 1) || (j > cols - 1));
         return array_p[i + rows * j];
     }
 
@@ -405,17 +395,12 @@ public:
     //Setters
     void set_value(const K &key, const V &value, int memory_layer)
     {
-        if (key > range - 1) {
-            throw std::out_of_range("Unknown seq type in Seq_type_str_p_map::operator(Seq_type)");
-        }
+        assert(key > range - 1);
         //Cannot fill memory layer without filling the ones downstream
-        if (memory_layer <= (memory_layer_ptr[key] + 1)) {
-            (*(value_ptr_arr + key + memory_layer * range)) = value;
-            //Setting a value at a given layer invalidate upper layers
-            memory_layer_ptr[key] = memory_layer;
-        } else {
-            throw std::out_of_range("Trying to access incorrect memory layer in Enum_fast_memory_map::set_value()");
-        }
+        assert(memory_layer <= (memory_layer_ptr[key] + 1));
+        (*(value_ptr_arr + key + memory_layer * range)) = value;
+        //Setting a value at a given layer invalidate upper layers
+        memory_layer_ptr[key] = memory_layer;
     }
 
     void multiply_all(double &prod_operand, int *memory_adresses)

--- a/src/igor/Core/Utils.h
+++ b/src/igor/Core/Utils.h
@@ -224,13 +224,13 @@ public:
 
     T &operator()(const int &i, const int &j)
     {
-        assert((i > rows - 1) || (j > cols - 1));
+        assert((i <= rows - 1) && (j <= cols - 1));
         return array_p[i + rows * j];
     }
 
     const T &operator()(const int &i, const int &j) const
     {
-        assert((i > rows - 1) || (j > cols - 1));
+        assert((i <= rows - 1) && (j <= cols - 1));
         return array_p[i + rows * j];
     }
 
@@ -395,7 +395,7 @@ public:
     //Setters
     void set_value(const K &key, const V &value, int memory_layer)
     {
-        assert(key > range - 1);
+        assert(key <= range - 1);
         //Cannot fill memory layer without filling the ones downstream
         assert(memory_layer <= (memory_layer_ptr[key] + 1));
         (*(value_ptr_arr + key + memory_layer * range)) = value;


### PR DESCRIPTION
- replace bounds check with assert (run the tests on ci/ubuntu using debug build in order to test these asserts)
- replace bitwise operators &| with logical ones (&& ||)
- avoid useless memory allocation in substr



|-| Alignments | Inference|
| --- |---|---|
|Before |  3.13 sec |  21.0 sec|
|After   |  0.92 sec | 15.7 sec|

(on a 8 cores (16 threads)  linux machine (Xeon(R) W-2145)