### PR TITLE
Feature/banded alignment

### DIFF
--- a/src/igor/Core/Aligner.cpp
+++ b/src/igor/Core/Aligner.cpp
@@ -30,6 +30,7 @@
 #include <cctype>
 #include <unordered_set>
 #include <cmath>
+#include <cstdlib>
 
 using namespace std;
 
@@ -345,7 +346,8 @@ forward_list<Alignment_data> Aligner::align_seq(string nt_seq, double score_thre
  *
  * \param [in] nt_seq the nucleotide sequence to study
  * \param [in] score_threshold The SW alignment score threshold to record an alignment
- * \param [in] best_align_only Only retain the best alignment for each genomic template.
+ * \param [in] best_align_only Only retain the best alignment for each genomic template. If several
+ * alignments tie for that best score, all of them are retained.
  * \param [in] best_gene_only Only retain the best gene/allele candidate (or best candidates if several have the same highest score).
  * \param [in] genomic_offset_bounds A hash map containing offsets lower and upper bounds for each genomic template. Keys of the map are the genomic templates names.
  * \param [in] restricted_genomic_list A set containing the names of the genes that should be aligned to the sequence.
@@ -572,7 +574,8 @@ void Aligner::align_seqs(string filename, vector<pair<const int, const string>> 
  * \param [in] sequence_list A forward list containing pairs of nt sequence and the corresponding index
  * \param [in] nt_seq the nucleotide sequence to study
  * \param [in] score_threshold The SW alignment score threshold to record an alignment
- * \param [in] best_align_only Only retain the best alignment for each genomic template.
+ * \param [in] best_align_only Only retain the best alignment for each genomic template. If several
+ * alignments tie for that best score, all of them are retained.
  * \param [in] best_gene_only Only retain the best gene/allele candidate (or best candidates if several have the same highest score).
  * \param [in] genomic_offset_bounds A hash map containing offsets lower and upper bounds for each genomic template. Keys of the map are the genomic templates names.
  * \param [in] rev_offset_frame Are offsets bounds given reversed? (offset defined based on the last sequence nt instead of the first). Default is false.
@@ -2068,6 +2071,282 @@ void initialize_sw_matrices(SwDPState &dp, const SwDPConfig &config)
     }
 }
 
+namespace band_bounds_detail {
+
+// long long throughout: min_offset/max_offset can be INT32_MIN/INT32_MAX (SwDPConfig's
+// "unconstrained" defaults), and j + min_offset (etc.) would overflow in 32-bit arithmetic.
+inline long long clamp_ll(long long v, long long lo, long long hi)
+{
+    return std::max(lo, std::min(hi, v));
+}
+
+// Best-case score of a path from the earliest possible seed on diagonal d0 (the row-0/col-0
+// boundary point on that diagonal) to interior cell (i,j), front-loading all diagonal (match)
+// moves before paying gap cost for the rest. Sound upper bound regardless of where the true seed
+// sits on diagonal d0: any other seed on that diagonal has strictly less remaining budget in both
+// directions. i,j are 1-based interior matrix coordinates (>=1).
+inline double seed_reach_score(long long i, long long j, long long d0, double m, long long g)
+{
+    const long long a = i - std::max<long long>(0, d0);
+    const long long b = j - std::max<long long>(0, -d0);
+    if (a < 0 || b < 0) {
+        // d0's own boundary point (max(0,d0), max(0,-d0)) doesn't fit in the matrix at all: this
+        // can only happen when [min_offset,max_offset] (via the caller's clamp) is so far outside
+        // the matrix's own feasible diagonal span that even the closest admissible diagonal has no
+        // valid seed -- not "a bad score", a genuinely impossible geometry. -infinity here (rather
+        // than a merely very negative finite value) is why fill_column_range's criterion also
+        // requires std::isfinite: a finite sentinel would still satisfy ">= -infinity" whenever
+        // score_threshold is itself left at its (default) -infinity, silently readmitting it.
+        return -std::numeric_limits<double>::infinity();
+    }
+    const long long gap_moves = std::llabs((i - j) - d0);
+    return m * static_cast<double>(std::min(a, b)) - static_cast<double>(g) * static_cast<double>(gap_moves);
+}
+
+// Best-case score of a path from interior cell (i,j) to the farthest reachable cell on diagonal
+// d1 (the row-(n_rows-1)/col-(n_cols-1) boundary point on that diagonal), front-loading all
+// diagonal moves. Mirror image of seed_reach_score for the "suffix cone" (flip_seqs==true) case:
+// here it is the *far* corner on diagonal d1, not the near one, that maximizes remaining budget.
+inline double target_reach_score(long long i, long long j, long long d1, double m, long long g, long long n_rows,
+                                 long long n_cols)
+{
+    const long long k = i - j;
+    const long long delta = d1 - k;
+    const long long a = (n_rows - 1 - i) - std::max<long long>(0, delta);
+    const long long b = (n_cols - 1 - j) - std::max<long long>(0, -delta);
+    if (a < 0 || b < 0) {
+        // Mirror image of seed_reach_score's feasibility guard: d1's own far-corner boundary point
+        // doesn't fit in the matrix from (i,j) onward at all.
+        return -std::numeric_limits<double>::infinity();
+    }
+    return m * static_cast<double>(std::min(a, b)) - static_cast<double>(g) * static_cast<double>(std::llabs(delta));
+}
+
+// Best-case additional score achievable continuing from (i,j) onward, extending (i,j)'s own
+// diagonal (zero further gap moves -- the cheapest possible continuation) all the way to the
+// matrix's far corner. Used as the "backward" half of the reachability bound: even a cell whose
+// best-case score AT (i,j) is unremarkable (or negative) may still be a necessary ancestor of a
+// later cell that clears score_threshold, since nothing in semi-global (non-reset) alignment mode
+// prevents a candidate's tracked score from dipping negative and recovering later.
+inline double remaining_extent_score(long long i, long long j, long long n_rows, long long n_cols, double m)
+{
+    return m * static_cast<double>(std::min(n_rows - 1 - i, n_cols - 1 - j));
+}
+
+// Finds a peak (index where extending further doesn't increase the value) of a weakly-unimodal
+// (non-decreasing then non-increasing, possibly with a flat plateau) integer-domain function over
+// [lo,hi], via the standard "find peak element" binary search. Used instead of a hand-derived
+// closed-form peak location because sweep_prefix/sweep_suffix's Combined criterion is a *sum* of
+// two concave pieces whose individual peaks don't align, making the combined peak's location
+// error-prone to derive by hand (see git history for a worked example of exactly that mistake).
+template <typename F>
+int find_peak(int lo, int hi, const F &f)
+{
+    while (lo < hi) {
+        const int mid = lo + (hi - lo) / 2;
+        if (f(mid) < f(mid + 1)) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+// Binary-searches the row range within [row_lo,row_hi] where a unimodal-in-i reach function
+// reaches score_threshold, given a row known to lie on or at its single peak/plateau within that
+// range. Shared by sweep_prefix and sweep_suffix, which differ only in which combined reach
+// function they evaluate -- see each caller's doc comment for the derivation and unimodality
+// argument. [row_lo,row_hi] is the already-feasible sub-range computed by the caller (see
+// feasible_row_range_prefix/suffix) -- restricting the search to it, rather than searching the
+// full [1,n_rows-1] and relying on seed_reach_score/target_reach_score's -infinity sentinel to
+// reject the rest, is what keeps find_peak's binary search correct: an extended plateau of tied
+// -infinity values elsewhere in [1,n_rows-1] would otherwise make it stop before ever reaching the
+// real (finite) peak.
+template <typename ReachAtRow>
+void fill_column_range(int row_lo, int row_hi, int i_peak, const ReachAtRow &reach_at_row, double score_threshold,
+                       int &lo_out, int &hi_out)
+{
+    if (row_lo > row_hi) {
+        return; // no feasible row at all in this column
+    }
+    const auto admissible = [&](int i) { return std::isfinite(reach_at_row(i)) && reach_at_row(i) >= score_threshold; };
+    if (!admissible(i_peak)) {
+        return; // whole column stays empty (lo_out > hi_out, the caller's default)
+    }
+    // Left boundary: non-decreasing on [row_lo, i_peak].
+    int lo = row_lo;
+    int hi = i_peak;
+    while (lo < hi) {
+        const int mid = lo + (hi - lo) / 2;
+        if (admissible(mid)) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    lo_out = lo;
+    // Right boundary: non-increasing on [i_peak, row_hi].
+    lo = i_peak;
+    hi = row_hi;
+    while (lo < hi) {
+        const int mid = lo + (hi - lo + 1) / 2;
+        if (admissible(mid)) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    hi_out = lo;
+}
+
+// Feasible row range for sweep_prefix's column j: the sub-range of [1,n_rows-1] where
+// seed_reach_score(i, j, clamp(i-j,d_lo,d_hi), ...) is finite (i.e. the clamped seed diagonal's
+// own boundary point actually fits in the matrix). Derived from the three-regime decomposition
+// (see sweep_prefix's doc comment): the middle "plateau" region i in [j+d_lo, j+d_hi] is always
+// feasible; the two flanking regions use a FIXED clamped diagonal (d_lo to the left, d_hi to the
+// right), so their feasibility reduces to a single column-level check each (not i-dependent) once
+// combined with the region's own a>=0 threshold on i.
+std::pair<int, int> feasible_row_range_prefix(int j, int n_rows, long long d_lo, long long d_hi)
+{
+    const long long i1 = static_cast<long long>(j) + d_lo;
+    const long long i2 = static_cast<long long>(j) + d_hi;
+    // Left region (i < i1): a = i - max(0,d_lo) (i-dependent threshold), b = j - max(0,-d_lo)
+    // (constant there) -- if b < 0 the whole left region is infeasible regardless of i.
+    long long lo = (j - std::max<long long>(0, -d_lo) < 0) ? i1 : std::max<long long>(1, std::max<long long>(0, d_lo));
+    // Right region (i > i2): a = i - max(0,d_hi) is always >= 0 there (i grows without bound),
+    // b = j - max(0,-d_hi) (constant there) -- if b < 0 the whole right region is infeasible.
+    long long hi = (j - std::max<long long>(0, -d_hi) < 0) ? i2 : static_cast<long long>(n_rows - 1);
+    lo = clamp_ll(lo, 1, n_rows - 1);
+    hi = clamp_ll(hi, 1, n_rows - 1);
+    return { static_cast<int>(lo), static_cast<int>(hi) };
+}
+
+// Feasible row range for sweep_suffix's column j: mirror of feasible_row_range_prefix for
+// target_reach_score's regions (see sweep_suffix's doc comment for why the shape differs -- here
+// the LEFT region's feasibility is i-independent, and the RIGHT region's has an i-dependent
+// upper threshold, the opposite asymmetry from the prefix case).
+std::pair<int, int> feasible_row_range_suffix(int j, int n_rows, int n_cols, long long d_lo, long long d_hi)
+{
+    const long long i1 = static_cast<long long>(j) + d_lo;
+    const long long i2 = static_cast<long long>(j) + d_hi;
+    // Left region (i < i1): a = n_rows-1-d_lo-j and b = n_cols-1-j are BOTH constant there;
+    // b >= 0 always holds for an interior column, so only the a-condition can exclude it.
+    long long lo = (static_cast<long long>(n_rows - 1) - d_lo - j < 0) ? i1 : 1;
+    // Right region (i > i2): a = n_rows-1-i is always >= 0 there; b = n_cols-1+d_hi-i imposes an
+    // upper bound i <= n_cols-1+d_hi.
+    long long hi = std::min<long long>(n_rows - 1, std::max<long long>(i2, static_cast<long long>(n_cols - 1) + d_hi));
+    lo = clamp_ll(lo, 1, n_rows - 1);
+    hi = clamp_ll(hi, 1, n_rows - 1);
+    return { static_cast<int>(lo), static_cast<int>(hi) };
+}
+
+// Per-column row range [lo(j), hi(j)] = {i in [1, n_rows-1] : Combined(i,j) >= score_threshold},
+// where
+//   Combined(i,j) = seed_reach_score(i, j, clamp(i-j,d_lo,d_hi), m, g)      -- forward: best case
+//                                                                              arriving at (i,j)
+//                                                                              from an admissible
+//                                                                              seed diagonal
+//                 + remaining_extent_score(i, j, n_rows, n_cols, m)         -- backward: best case
+//                                                                              continuing from
+//                                                                              (i,j) to the far
+//                                                                              corner
+// is a sound upper bound on the total score of *any* real path (through any real sequence
+// content) that passes through (i,j) after seeding on an admissible diagonal. If Combined(i,j) is
+// below score_threshold, no such path could ever have (i,j) contribute to a candidate whose
+// eventual peak reaches threshold -- regardless of what happens before or after (i,j) along the
+// real, data-dependent path -- so (i,j) is safe to skip. Comparing against the real
+// score_threshold (not a hardcoded 0) is what makes this sound for semi-global (non-reset)
+// alignment modes, where a candidate's actual tracked score can legitimately dip negative and
+// later recover; -infinity (SwDPConfig's default) degrades this to "reachable at all" (no
+// score-based exclusion), which is correct since nothing is excluded by an unset threshold.
+//
+// Both terms are concave (unimodal) in i for fixed j (seed_reach_score: see its own three-regime
+// argument; remaining_extent_score: min of a decreasing and a constant term), so their sum is too
+// -- find_peak() locates a point on the combined peak/plateau, then fill_column_range finds the
+// >=score_threshold boundary on each side.
+SwBandBounds sweep_prefix(int n_rows, int n_cols, long long d_lo, long long d_hi, double m, int gap_penalty,
+                          double score_threshold)
+{
+    SwBandBounds result;
+    result.lo.assign(n_cols, 1);
+    result.hi.assign(n_cols, 0);
+    if (d_lo > d_hi) {
+        return result;
+    }
+
+    for (int j = 1; j != n_cols; ++j) {
+        const auto [row_lo, row_hi] = feasible_row_range_prefix(j, n_rows, d_lo, d_hi);
+        if (row_lo > row_hi) {
+            continue; // no seed diagonal in [d_lo,d_hi] has a geometrically valid boundary point
+        }
+        const auto combined = [&](int i) {
+            return seed_reach_score(i, j, clamp_ll(i - j, d_lo, d_hi), m, gap_penalty)
+                 + remaining_extent_score(i, j, n_rows, n_cols, m);
+        };
+        const int i_peak = find_peak(row_lo, row_hi, combined);
+        fill_column_range(row_lo, row_hi, i_peak, combined, score_threshold, result.lo[j], result.hi[j]);
+    }
+    return result;
+}
+
+// Mirror image of sweep_prefix for the "suffix cone" (flip_seqs==true): offset restricts the
+// diagonal of the *target* (running-max) cell, not the seed, so Combined(i,j) instead sums
+//   remaining_extent_score-style PREFIX credit: m * min(i,j)   -- best case arriving at (i,j) from
+//                                                                  ANY (unrestricted) seed
+//                 + target_reach_score(i, j, clamp(i-j,d_lo,d_hi), m, g, n_rows, n_cols)
+//                                                              -- best case continuing from (i,j)
+//                                                                 to an admissible target diagonal
+// Same unimodality argument as sweep_prefix applies (m*min(i,j) is concave in i for fixed j by the
+// same "min of increasing-then-flat" shape as seed_reach_score's own plateau term).
+SwBandBounds sweep_suffix(int n_rows, int n_cols, long long d_lo, long long d_hi, double m, int gap_penalty,
+                          double score_threshold)
+{
+    SwBandBounds result;
+    result.lo.assign(n_cols, 1);
+    result.hi.assign(n_cols, 0);
+    if (d_lo > d_hi) {
+        return result;
+    }
+
+    for (int j = 1; j != n_cols; ++j) {
+        const auto [row_lo, row_hi] = feasible_row_range_suffix(j, n_rows, n_cols, d_lo, d_hi);
+        if (row_lo > row_hi) {
+            continue; // no target diagonal in [d_lo,d_hi] has a geometrically valid far-corner point
+        }
+        const auto combined = [&](int i) {
+            return m * static_cast<double>(std::min(i, j))
+                 + target_reach_score(i, j, clamp_ll(i - j, d_lo, d_hi), m, gap_penalty, n_rows, n_cols);
+        };
+        const int i_peak = find_peak(row_lo, row_hi, combined);
+        fill_column_range(row_lo, row_hi, i_peak, combined, score_threshold, result.lo[j], result.hi[j]);
+    }
+    return result;
+}
+
+} // namespace band_bounds_detail
+
+SwBandBounds compute_band_bounds(int n_rows, int n_cols, int min_offset, int max_offset, double max_match_score,
+                                 int gap_penalty, double score_threshold, bool flip_seqs, size_t data_seq_size,
+                                 size_t genomic_seq_size)
+{
+    using namespace band_bounds_detail;
+
+    if (!flip_seqs) {
+        // offset == i - j at the seed (traceback_sw_alignments' non-flip branch), so min_offset/
+        // max_offset bound the seed diagonal directly.
+        return sweep_prefix(n_rows, n_cols, min_offset, max_offset, max_match_score, gap_penalty, score_threshold);
+    }
+
+    // flip_seqs == true: offset = (j_end - i_end) + C, C = data_seq_size - genomic_seq_size
+    // (traceback_sw_alignments' flip branch, using the running-max cell i_end,j_end) =>
+    // i_end - j_end = C - offset, for offset in [min_offset, max_offset].
+    const long long C = static_cast<long long>(data_seq_size) - static_cast<long long>(genomic_seq_size);
+    const long long suffix_d_lo = C - static_cast<long long>(max_offset);
+    const long long suffix_d_hi = C - static_cast<long long>(min_offset);
+    return sweep_suffix(n_rows, n_cols, suffix_d_lo, suffix_d_hi, max_match_score, gap_penalty, score_threshold);
+}
+
 /**
  * Extend alignment mismatches to the 5' (left) side assuming no indels in the extended region.
  * This function extends from the start of the core alignment (i, j) towards lower indices
@@ -2540,6 +2819,31 @@ IGOR_ALWAYS_INLINE void fill_sw_matrix_cell(int i, int j, int n_rows, double *sc
  * \param int_genomic_sequence  Prepared (possibly flipped) reference sequence, 0-based.
  * \param dp  DP workspace whose matrices were already initialized by initialize_sw_matrices.
  */
+namespace {
+// Deeply uncompetitive score written to DP cells that fall outside the computed band (see
+// SwDPState::lo/hi, swalign::compute_band_bounds), so a neighboring in-band cell's idx_up/
+// idx_left/idx_diag read (fill_sw_matrix_cell) finds a well-defined value instead of the garbage
+// Matrix<T>'s constructor leaves behind (no zero-initialization -- see Utils.h). Comfortably below
+// any achievable real DP score (bounded by roughly max_match_score or gap_penalty times
+// n_rows+n_cols for realistic alignment sizes) while staying far from int32 overflow after
+// fill_sw_matrix_cell's static_cast<int> arithmetic on a single -gap_penalty hop off of it.
+constexpr double SW_BAND_SENTINEL_SCORE = -1.0e8;
+} // namespace
+
+// Writes the sentinel to cell (i,j) across all four DP matrices sharing SwDPState's linear index
+// convention (idx = i + n_rows*j, see fill_sw_matrix_cell) -- not just score_matrix, because the
+// local-alignment reset branch in fill_sw_matrix_cell unconditionally reads numb_trk[idx_diag]
+// regardless of which move wins the argmax, so a sentinel cell's tracker must also be well-defined
+// (-1, the same "untracked" convention initialize_sw_matrices uses for the true boundary).
+void seed_band_sentinel_cell(int i, int j, int n_rows, double *score, int *row_mem, int *col_mem, int *numb_trk)
+{
+    const int idx = i + n_rows * j;
+    score[idx] = SW_BAND_SENTINEL_SCORE;
+    row_mem[idx] = 0;
+    col_mem[idx] = 0;
+    numb_trk[idx] = -1;
+}
+
 void fill_sw_score_matrix(const Int_Str &int_data_sequence, const Int_Str &int_genomic_sequence, SwDPState &dp,
                           const SwDPConfig &config)
 {
@@ -2557,25 +2861,110 @@ void fill_sw_score_matrix(const Int_Str &int_data_sequence, const Int_Str &int_g
 #define IGOR_SW_BAND_WIDTH 8
     constexpr int BAND_WIDTH = IGOR_SW_BAND_WIDTH;
 
+    // Column 0 (the init boundary) is fully valid for every row already, so seeding the "previous
+    // column range" bookkeeping with it means the first stripe/tail column needs no special case
+    // in the fringe logic below.
+    int prev_lo = 0;
+    int prev_hi = n_rows - 1;
+
     // Always start at index 1 since first column and first row are initialization values
     int j = 1;
     for (; j + BAND_WIDTH <= dp.n_cols; j += BAND_WIDTH) {
-        for (int i = 1; i != dp.n_rows; ++i) {
+        // Restrict the row loop to the UNION of this stripe's 8 individual column ranges (dp.lo/
+        // dp.hi), not each column's own tight range: the inner unrolled loop below fires for all 8
+        // columns unconditionally (that uniformity is what gives it the ILP the routine's own
+        // traversal-order comment describes), so a per-column conditional inside it would undo
+        // that. The union costs a little slack at a stripe's edges -- at most BAND_WIDTH-1 extra
+        // columns' worth per stripe boundary -- in exchange for leaving that loop untouched.
+        int lo_stripe = n_rows;
+        int hi_stripe = 0;
+        for (int b = 0; b != BAND_WIDTH; ++b) {
+            if (dp.lo[j + b] <= dp.hi[j + b]) {
+                lo_stripe = std::min(lo_stripe, dp.lo[j + b]);
+                hi_stripe = std::max(hi_stripe, dp.hi[j + b]);
+            }
+        }
+        lo_stripe = std::max(lo_stripe, 1);
+        hi_stripe = std::min(hi_stripe, n_rows - 1);
+
+        if (lo_stripe > hi_stripe) {
+            // Whole stripe is empty: none of its 8 columns get computed, so the "previous column"
+            // bookkeeping for whatever comes next must reflect that (fully uninitialized), not
+            // silently keep referring to the stripe before this one.
+            prev_lo = 1;
+            prev_hi = 0;
+            continue;
+        }
+
+        // Left fringe: sentinel newly-exposed rows of the previous column (j-1) -- read via
+        // idx_left by this stripe's leftmost column (b=0) at every row in [lo_stripe,hi_stripe],
+        // and via idx_diag by that same column's first row, hence starting one row earlier.
+        for (int row = std::max(1, lo_stripe - 1); row <= hi_stripe; ++row) {
+            if (row < prev_lo || row > prev_hi) {
+                seed_band_sentinel_cell(row, j - 1, n_rows, score, row_mem, col_mem, numb_trk);
+            }
+        }
+        // Top fringe: sentinel row (lo_stripe-1) across this whole stripe's own columns -- read via
+        // idx_up (and, for b>=1, idx_diag) by the stripe's first processed row.
+        if (lo_stripe > 1) {
+            for (int b = 0; b != BAND_WIDTH; ++b) {
+                seed_band_sentinel_cell(lo_stripe - 1, j + b, n_rows, score, row_mem, col_mem, numb_trk);
+            }
+        }
+
+        for (int i = lo_stripe; i <= hi_stripe; ++i) {
             IGOR_UNROLL(IGOR_SW_BAND_WIDTH)
             for (int b = 0; b != BAND_WIDTH; ++b) {
                 fill_sw_matrix_cell(i, j + b, n_rows, score, row_mem, col_mem, numb_trk, dp.candidates,
                                     reset_negative_scores, config, int_data_sequence, int_genomic_sequence);
             }
         }
+
+        prev_lo = lo_stripe;
+        prev_hi = hi_stripe;
     }
-    // Remaining columns too few to fill a whole band.
+    // Remaining columns too few to fill a whole band: banded per-column, same fringe scheme as
+    // above but without the stripe-wide union (nothing to keep uniform for an unrolled loop here).
     for (; j != dp.n_cols; ++j) {
-        for (int i = 1; i != dp.n_rows; ++i) {
+        const int col_lo = std::max(dp.lo[j], 1);
+        const int col_hi = std::min(dp.hi[j], n_rows - 1);
+        if (dp.lo[j] > dp.hi[j] || col_lo > col_hi) {
+            prev_lo = 1;
+            prev_hi = 0;
+            continue;
+        }
+
+        for (int row = std::max(1, col_lo - 1); row <= col_hi; ++row) {
+            if (row < prev_lo || row > prev_hi) {
+                seed_band_sentinel_cell(row, j - 1, n_rows, score, row_mem, col_mem, numb_trk);
+            }
+        }
+        if (col_lo > 1) {
+            seed_band_sentinel_cell(col_lo - 1, j, n_rows, score, row_mem, col_mem, numb_trk);
+        }
+
+        for (int i = col_lo; i <= col_hi; ++i) {
             fill_sw_matrix_cell(i, j, n_rows, score, row_mem, col_mem, numb_trk, dp.candidates, reset_negative_scores,
                                 config, int_data_sequence, int_genomic_sequence);
         }
+
+        prev_lo = col_lo;
+        prev_hi = col_hi;
     }
 #undef IGOR_SW_BAND_WIDTH
+}
+
+// Best (highest) entry of a substitution matrix: the maximum score a single diagonal move could
+// ever achieve, used as the upper bound "m" in compute_band_bounds's reachability math.
+double max_substitution_score(const Matrix<double> &substitution_matrix)
+{
+    double max_score = substitution_matrix(0, 0);
+    for (int i = 0; i != substitution_matrix.get_n_rows(); ++i) {
+        for (int j = 0; j != substitution_matrix.get_n_cols(); ++j) {
+            max_score = std::max(max_score, substitution_matrix(i, j));
+        }
+    }
+    return max_score;
 }
 
 } // namespace swalign
@@ -2603,7 +2992,12 @@ list<pair<int, Alignment_data>> sw_align(const Int_Str &int_data_sequence, const
     const int n_rows = static_cast<int>(prepared_inputs.data_sequence.size()) + 1;
     const int n_cols = static_cast<int>(prepared_inputs.genomic_sequence.size()) + 1;
 
-    SwDPState dp(n_rows, n_cols);
+    SwBandBounds band = compute_band_bounds(n_rows, n_cols, config.min_offset, config.max_offset,
+                                            max_substitution_score(config.substitution_matrix), config.gap_penalty,
+                                            config.score_threshold, config.alignment_mode.reverse_sequences,
+                                            int_data_sequence.size(), int_genomic_sequence.size());
+
+    SwDPState dp(n_rows, n_cols, std::move(band));
     initialize_sw_matrices(dp, config);
     fill_sw_score_matrix(prepared_inputs.data_sequence, prepared_inputs.genomic_sequence, dp, config);
 

--- a/src/igor/Core/Aligner.h
+++ b/src/igor/Core/Aligner.h
@@ -428,7 +428,9 @@ struct SwAlignmentMode
  * Fields
  * ------
  * score_threshold  Minimum score an alignment must reach to be returned.
- * best_only        Retain only the alignment(s) reaching the best score for this call.
+ * best_only        Retain only the alignment(s) reaching the best score for this call. If several
+ *                   candidates tie for that best score, all of them are returned -- best_only
+ *                   guarantees the top score, not a single alignment.
  * min_offset       Lower bound on the offset (genomic-vs-query position).
  * max_offset       Upper bound on the offset.
  * alignment_mode    Boundary and orientation policy for the DP run.

--- a/src/igor/Core/AlignerInternal.h
+++ b/src/igor/Core/AlignerInternal.h
@@ -59,6 +59,22 @@ struct CORE_TESTING_EXPORT SwCandidate
 };
 
 /**
+ * Column-indexed row range(s) restricting which DP cells are worth filling, derived in closed
+ * form from an SwDPConfig's min_offset/max_offset/gap_penalty/substitution_matrix/score_threshold
+ * -- see compute_band_bounds's doc comment for the derivation.
+ *
+ * lo/hi are sized n_cols; column 0 (the init boundary, always fully valid) is left at its default
+ * {lo=1,hi=0} and never consulted. hi[j] < lo[j] means column j is empty: no cell in that column
+ * can be part of any alignment admissible under min_offset/max_offset/score_threshold, so the
+ * whole column can be skipped.
+ */
+struct CORE_TESTING_EXPORT SwBandBounds
+{
+    std::vector<int> lo;
+    std::vector<int> hi;
+};
+
+/**
  * Internal workspace for one Smith-Waterman DP execution.
  *
  * Groups the four DP matrices and the candidate-tracking vector that are
@@ -76,6 +92,12 @@ struct CORE_TESTING_EXPORT SwDPState
     Matrix<int> col_memory_matrix;
     Matrix<int> alignment_numb_tracker;
     std::vector<SwCandidate> candidates;
+    // Column-indexed row bounds fill_sw_score_matrix restricts its fill to (see SwBandBounds).
+    // Defaults to the full [1,n_rows-1] range for every column, i.e. unbanded, so constructing an
+    // SwDPState without an explicit SwBandBounds (as existing whitebox tests do) behaves exactly
+    // as before this field was added.
+    std::vector<int> lo;
+    std::vector<int> hi;
 
     SwDPState(int nr, int nc)
         : n_rows(nr),
@@ -83,7 +105,21 @@ struct CORE_TESTING_EXPORT SwDPState
           score_matrix(nr, nc),
           row_memory_matrix(nr, nc),
           col_memory_matrix(nr, nc),
-          alignment_numb_tracker(nr, nc)
+          alignment_numb_tracker(nr, nc),
+          lo(nc, 1),
+          hi(nc, nr - 1)
+    {
+    }
+
+    SwDPState(int nr, int nc, SwBandBounds bounds)
+        : n_rows(nr),
+          n_cols(nc),
+          score_matrix(nr, nc),
+          row_memory_matrix(nr, nc),
+          col_memory_matrix(nr, nc),
+          alignment_numb_tracker(nr, nc),
+          lo(std::move(bounds.lo)),
+          hi(std::move(bounds.hi))
     {
     }
 };
@@ -106,5 +142,69 @@ struct CORE_TESTING_EXPORT SwPreparedInputs
  * \param config  Run policy; alignment_mode's leading/trailing-free flags and gap_penalty are consulted.
  */
 CORE_TESTING_EXPORT void initialize_sw_matrices(SwDPState &dp, const SwDPConfig &config);
+
+/**
+ * Compute, for each column of the (n_rows x n_cols) prepared DP matrix, the contiguous range of
+ * rows that can possibly belong to an alignment whose offset would pass config.min_offset/
+ * max_offset (and, if set, config.score_threshold) -- i.e. the "cone" a banded fill can safely
+ * restrict itself to, derived purely from the scoring scheme rather than a fixed diagonal +
+ * tolerance.
+ *
+ * The math (see the per-call closed-form derivation in Aligner.cpp): a path using only diagonal
+ * (score up to max_match_score per step) and gap (cost gap_penalty per step) moves can reach cell
+ * (i,j) from a seed on diagonal d0 with score at most
+ *   m * min(i - max(0,d0), j - max(0,-d0)) - g * |(i-j) - d0|
+ * (front-load all diagonal moves, pay gap cost for the rest) -- a sound upper bound regardless of
+ * where the true seed sits on that diagonal.
+ *
+ * Critically, this "forward" bound alone is NOT a valid pruning criterion on its own for
+ * semi-global (non-reset) alignment modes (V/D/J-gene): unlike vanilla local alignment, a
+ * candidate's tracked score is never reset when it would go negative, so a real candidate's
+ * eventual peak can occur arbitrarily far downstream of a cell whose own best-case score is
+ * unremarkable or negative -- excluding such a cell outright would silently drop legitimate
+ * alignments. The correct criterion combines the forward bound with a "backward" bound -- the
+ * best additional score achievable continuing from (i,j) to the matrix's far corner, extending
+ * (i,j)'s own diagonal (the cheapest possible continuation, zero further gaps):
+ *   Combined(i,j) = seed_reach_score(i,j,d0) + m * min(n_rows-1-i, n_cols-1-j)
+ * compared against the *actual* config.score_threshold (not a hardcoded 0). If Combined(i,j) is
+ * below score_threshold, no real path through (i,j) -- for any real sequence content -- could
+ * ever contribute to a candidate whose eventual peak reaches threshold, so (i,j) is safe to skip.
+ * With score_threshold left at -infinity (SwDPConfig's default), Combined(i,j) is always finite
+ * and the comparison always holds, correctly degrading to "no score-based exclusion at all" --
+ * only geometric reachability from an admissible offset diagonal restricts the band in that case
+ * (a simple quadrant/rectangle cut, not a narrowing cone). With a real, finite threshold, the
+ * combined bound genuinely narrows near the seed (too little accumulated yet) and again near the
+ * far corner (too little room left to make up a bad start), producing the widening-then-plateauing
+ * cone shape the offset/score_threshold restriction is meant to give.
+ *
+ * Both the forward and backward terms are concave/unimodal in i (for fixed j) and in d0 (for
+ * fixed i,j, once optimally chosen), which is what makes an O(n_rows + n_cols) per-column sweep
+ * possible instead of an O(n_rows * n_cols) scan.
+ *
+ * Critical asymmetry (verified against traceback_sw_alignments's own offset computation): when
+ * flip_seqs is false (V/D-gene alignment), the traceback computes offset from the alignment's
+ * *seed* (start) cell, so min_offset/max_offset restrict the seed's diagonal directly ("prefix
+ * cone"): the forward term is offset-restricted, the backward term unrestricted. When flip_seqs is
+ * true (J-gene alignment), offset is instead computed from the cell where the candidate's
+ * *running-max* score was recorded, which can drift arbitrarily far from an *unrestricted* seed --
+ * so min_offset/max_offset instead restrict the diagonal of that downstream cell ("suffix cone"):
+ * the backward term is offset-restricted, the forward term unrestricted. These are not mirror
+ * images of one another: which side is offset-restricted swaps with flip_seqs.
+ *
+ * \param n_rows            Prepared DP matrix row count (query length + 1).
+ * \param n_cols             Prepared DP matrix column count (template length + 1).
+ * \param min_offset        Same field as SwDPConfig::min_offset.
+ * \param max_offset        Same field as SwDPConfig::max_offset.
+ * \param max_match_score   Best (highest) entry of the substitution matrix in use for this call.
+ * \param gap_penalty       Same field as SwDPConfig::gap_penalty.
+ * \param score_threshold   Same field as SwDPConfig::score_threshold; -infinity disables this axis.
+ * \param flip_seqs         config.alignment_mode.reverse_sequences, AFTER effective_sw_mode_for_dp.
+ * \param data_seq_size     Original (unflipped) query sequence length.
+ * \param genomic_seq_size  Original (unflipped) reference sequence length.
+ */
+CORE_TESTING_EXPORT SwBandBounds compute_band_bounds(int n_rows, int n_cols, int min_offset, int max_offset,
+                                                     double max_match_score, int gap_penalty,
+                                                     double score_threshold, bool flip_seqs, size_t data_seq_size,
+                                                     size_t genomic_seq_size);
 
 } // namespace swalign

--- a/tst/igor/Core/CMakeLists.txt
+++ b/tst/igor/Core/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CORE_TEST_SOURCES
     test_generation.cpp
     test_inference.cpp
     test_sanity.cpp
+    test_sw_band_bounds.cpp
     test_utils.cpp
     AlignerTestUtils.cpp
 )

--- a/tst/igor/Core/test_sw_band_bounds.cpp
+++ b/tst/igor/Core/test_sw_band_bounds.cpp
@@ -1,0 +1,383 @@
+/*
+ * test_sw_band_bounds.cpp
+ *
+ *  Unit tests for swalign::compute_band_bounds, the closed-form banded-alignment "cone"
+ *  computation -- see its doc comment in AlignerInternal.h for the derivation.
+ *
+ *  This source code is distributed as part of the IGoR software.
+ *  IGoR (Inference and Generation of Repertoires) is a versatile software to analyze and model immune receptors
+ *  generation, selection, mutation and all other processes.
+ *   Copyright (C) 2017  Quentin Marcou
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_random.hpp>
+
+#include <igor/Core/AlignerInternal.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <vector>
+
+using swalign::compute_band_bounds;
+using swalign::SwBandBounds;
+
+namespace {
+
+// Independent brute-force reference for the PREFIX (seed-restricted) cone: for every column j and
+// row i, enumerates every seed diagonal d0 in [d_lo,d_hi] directly (rather than using
+// compute_band_bounds's peak-finding + binary search) and combines the forward (seed-to-(i,j))
+// and backward ((i,j)-to-far-corner) terms exactly as compute_band_bounds's Combined(i,j) does,
+// so it validates that shortcut -- and the peak-finding -- against a naive O(range) search over
+// the exact same criterion. d_lo/d_hi are clamped to the matrix's own feasible diagonal span
+// first, matching how compute_band_bounds's clamp(i-j,...) degenerates to an unconstrained
+// "i-j itself" when given INT32_MIN/MAX bounds.
+SwBandBounds brute_force_prefix(int n_rows, int n_cols, long long d_lo, long long d_hi, double m, int g,
+                                double score_threshold)
+{
+    const long long lo = std::max(d_lo, static_cast<long long>(-(n_cols - 1)));
+    const long long hi = std::min(d_hi, static_cast<long long>(n_rows - 1));
+
+    SwBandBounds result;
+    result.lo.assign(n_cols, 1);
+    result.hi.assign(n_cols, 0);
+    if (lo > hi) {
+        return result;
+    }
+
+    for (int j = 1; j != n_cols; ++j) {
+        for (int i = 1; i != n_rows; ++i) {
+            double best = -std::numeric_limits<double>::infinity();
+            for (long long d0 = lo; d0 <= hi; ++d0) {
+                const long long a = i - std::max<long long>(0, d0);
+                const long long b = j - std::max<long long>(0, -d0);
+                if (a < 0 || b < 0) {
+                    continue; // d0's own boundary seed point doesn't fit in the matrix at all
+                }
+                const double gap_moves = static_cast<double>(std::llabs(static_cast<long long>(i - j) - d0));
+                const double forward =
+                        m * static_cast<double>(std::min(a, b)) - static_cast<double>(g) * gap_moves;
+                best = std::max(best, forward);
+            }
+            const double backward = m * std::min(n_rows - 1 - i, n_cols - 1 - j);
+            if (std::isfinite(best) && best + backward >= score_threshold) {
+                if (result.lo[j] > result.hi[j]) {
+                    result.lo[j] = i;
+                }
+                result.hi[j] = i;
+            }
+        }
+    }
+    return result;
+}
+
+// Mirror-image brute force for the SUFFIX (target-diagonal-restricted) cone: enumerates every
+// target diagonal d1 in [d_lo,d_hi] directly, validating compute_band_bounds's suffix peak-finding
+// shortcut the same way brute_force_prefix validates the prefix one.
+SwBandBounds brute_force_suffix(int n_rows, int n_cols, long long d_lo, long long d_hi, double m, int g,
+                                double score_threshold)
+{
+    const long long lo = std::max(d_lo, static_cast<long long>(-(n_cols - 1)));
+    const long long hi = std::min(d_hi, static_cast<long long>(n_rows - 1));
+
+    SwBandBounds result;
+    result.lo.assign(n_cols, 1);
+    result.hi.assign(n_cols, 0);
+    if (lo > hi) {
+        return result;
+    }
+
+    for (int j = 1; j != n_cols; ++j) {
+        for (int i = 1; i != n_rows; ++i) {
+            double best = -std::numeric_limits<double>::infinity();
+            const long long k = i - j;
+            for (long long d1 = lo; d1 <= hi; ++d1) {
+                const long long delta = d1 - k;
+                const long long a = (n_rows - 1 - i) - std::max<long long>(0, delta);
+                const long long b = (n_cols - 1 - j) - std::max<long long>(0, -delta);
+                if (a < 0 || b < 0) {
+                    continue; // d1's own far-corner target point doesn't fit in the matrix at all
+                }
+                const double forward = m * static_cast<double>(std::min(a, b))
+                                      - static_cast<double>(g) * static_cast<double>(std::llabs(delta));
+                best = std::max(best, forward);
+            }
+            const double backward = m * std::min(i, j);
+            if (std::isfinite(best) && best + backward >= score_threshold) {
+                if (result.lo[j] > result.hi[j]) {
+                    result.lo[j] = i;
+                }
+                result.hi[j] = i;
+            }
+        }
+    }
+    return result;
+}
+
+std::string describe_bounds(const SwBandBounds &bounds)
+{
+    std::ostringstream out;
+    for (size_t j = 0; j < bounds.lo.size(); ++j) {
+        out << "  col " << j << ": [" << bounds.lo[j] << "," << bounds.hi[j] << "]"
+            << (bounds.lo[j] > bounds.hi[j] ? " (empty)" : "") << "\n";
+    }
+    return out.str();
+}
+
+void require_bounds_equal(const SwBandBounds &actual, const SwBandBounds &expected)
+{
+    INFO("actual:\n" << describe_bounds(actual) << "expected:\n" << describe_bounds(expected));
+    REQUIRE(actual.lo.size() == expected.lo.size());
+    REQUIRE(actual.hi.size() == expected.hi.size());
+    for (size_t j = 0; j < expected.lo.size(); ++j) {
+        // Normalize "empty" representations: compute_band_bounds and the brute-force reference
+        // may pick different but equally-valid lo>hi sentinel pairs for an empty column.
+        const bool actual_empty = actual.lo[j] > actual.hi[j];
+        const bool expected_empty = expected.lo[j] > expected.hi[j];
+        INFO("column " << j);
+        REQUIRE(actual_empty == expected_empty);
+        if (!expected_empty) {
+            REQUIRE(actual.lo[j] == expected.lo[j]);
+            REQUIRE(actual.hi[j] == expected.hi[j]);
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("compute_band_bounds is unconstrained when offsets span INT32_MIN/INT32_MAX",
+          "[aligner][sw][band_bounds]")
+{
+    const int n_rows = 8;
+    const int n_cols = 11;
+    const double m = 2.0;
+    const int g = 1;
+
+    SECTION("flip_seqs = false")
+    {
+        const SwBandBounds bounds = compute_band_bounds(n_rows, n_cols, std::numeric_limits<int>::min(),
+                                                        std::numeric_limits<int>::max(), m, g,
+                                                        -std::numeric_limits<double>::infinity(), false, 7, 10);
+        for (int j = 1; j != n_cols; ++j) {
+            INFO("column " << j);
+            REQUIRE(bounds.lo[j] == 1);
+            REQUIRE(bounds.hi[j] == n_rows - 1);
+        }
+    }
+
+    SECTION("flip_seqs = true")
+    {
+        const SwBandBounds bounds = compute_band_bounds(n_rows, n_cols, std::numeric_limits<int>::min(),
+                                                        std::numeric_limits<int>::max(), m, g,
+                                                        -std::numeric_limits<double>::infinity(), true, 7, 10);
+        for (int j = 1; j != n_cols; ++j) {
+            INFO("column " << j);
+            REQUIRE(bounds.lo[j] == 1);
+            REQUIRE(bounds.hi[j] == n_rows - 1);
+        }
+    }
+}
+
+TEST_CASE("compute_band_bounds matches brute-force enumeration across randomized small configs",
+          "[aligner][sw][band_bounds]")
+{
+    std::mt19937_64 rng(123456789ULL);
+    std::uniform_int_distribution<int> dim_dist(2, 14);
+    std::uniform_int_distribution<int> offset_dist(-12, 12);
+    std::uniform_real_distribution<double> match_dist(0.5, 5.0);
+    std::uniform_int_distribution<int> gap_dist(1, 6);
+    // Mix -infinity (the SwDPConfig default -- exercises the "no score-based exclusion" path) with
+    // real, sometimes-restrictive thresholds spanning comfortably-reachable to unreachable values.
+    std::uniform_real_distribution<double> threshold_dist(-40.0, 40.0);
+    std::uniform_int_distribution<int> use_real_threshold_dist(0, 1);
+
+    for (int trial = 0; trial != 200; ++trial) {
+        const int n_rows = dim_dist(rng);
+        const int n_cols = dim_dist(rng);
+        const int a = offset_dist(rng);
+        const int b = offset_dist(rng);
+        const int min_offset = std::min(a, b);
+        const int max_offset = std::max(a, b);
+        const double m = match_dist(rng);
+        const int g = gap_dist(rng);
+        const int data_seq_size = n_rows - 1;
+        const int genomic_seq_size = n_cols - 1;
+        const double score_threshold = use_real_threshold_dist(rng) ? threshold_dist(rng)
+                                                                    : -std::numeric_limits<double>::infinity();
+
+        INFO("trial=" << trial << " n_rows=" << n_rows << " n_cols=" << n_cols << " min_offset=" << min_offset
+                       << " max_offset=" << max_offset << " m=" << m << " g=" << g
+                       << " score_threshold=" << score_threshold);
+
+        {
+            const SwBandBounds actual = compute_band_bounds(n_rows, n_cols, min_offset, max_offset, m, g,
+                                                             score_threshold, false, data_seq_size, genomic_seq_size);
+            const SwBandBounds expected =
+                    brute_force_prefix(n_rows, n_cols, min_offset, max_offset, m, g, score_threshold);
+            require_bounds_equal(actual, expected);
+        }
+        {
+            const SwBandBounds actual = compute_band_bounds(n_rows, n_cols, min_offset, max_offset, m, g,
+                                                             score_threshold, true, data_seq_size, genomic_seq_size);
+            // flip_seqs=true's suffix side uses target diagonal range [C-max_offset, C-min_offset]
+            // with C = data_seq_size - genomic_seq_size (see compute_band_bounds's doc comment).
+            const long long C = static_cast<long long>(data_seq_size) - static_cast<long long>(genomic_seq_size);
+            const SwBandBounds expected_suffix =
+                    brute_force_suffix(n_rows, n_cols, C - max_offset, C - min_offset, m, g, score_threshold);
+            require_bounds_equal(actual, expected_suffix);
+        }
+    }
+}
+
+TEST_CASE("without a real score_threshold, offset restriction alone gives a rectangle, not a cone",
+          "[aligner][sw][band_bounds]")
+{
+    // -infinity is SwDPConfig's default: Combined(i,j) is always finite, so ">= -infinity" holds
+    // everywhere the offset-restricted seed diagonal is geometrically defined at all -- there is
+    // no score-based narrowing. But the seed diagonal's own boundary point (i0=max(0,offset),
+    // j0=0 here, since offset>=0) is a genuine geometric floor: no row before i0 is reachable at
+    // all, in ANY column. So the expected shape is a RECTANGLE -- a single constant row cutoff at
+    // i0, same for every column, unbounded above -- not the gradually-widening-from-row-1 shape a
+    // "narrowing cone" would produce. This documents the "rectangle, not cone" finding directly:
+    // offset alone restricts *which* seed diagonal is admissible and where its floor sits, not how
+    // far a candidate may drift from it.
+    const int n_rows = 40;
+    const int n_cols = 40;
+    const double m = 2.0;
+    const int g = 1;
+    const int offset = 3;
+
+    const SwBandBounds bounds = compute_band_bounds(n_rows, n_cols, offset, offset, m, g,
+                                                     -std::numeric_limits<double>::infinity(), false, n_rows - 1,
+                                                     n_cols - 1);
+
+    for (int j = 1; j != n_cols; ++j) {
+        INFO("column " << j);
+        REQUIRE(bounds.lo[j] == offset); // constant floor i0 = max(0,offset) = offset, every column
+        REQUIRE(bounds.hi[j] == n_rows - 1); // unbounded above: no threshold-based narrowing
+    }
+}
+
+TEST_CASE("with a real score_threshold, offset restriction DOES produce a genuine widening-then-"
+          "narrowing cone",
+          "[aligner][sw][band_bounds]")
+{
+    // The forward+backward Combined bound along the exact admissible diagonal itself is constant
+    // (m * (n_rows-1-offset), see compute_band_bounds's doc comment): every column's "on-diagonal"
+    // cell scores identically in the best case, so a threshold comfortably below that constant
+    // still empties out both ends of the matrix (too little accumulated near the seed, too little
+    // remaining room near the far corner) while leaving a genuinely widened region in the middle --
+    // the cone shape the offset/score_threshold restriction is meant to produce.
+    const int n_rows = 40;
+    const int n_cols = 40;
+    const double m = 2.0;
+    const int g = 1;
+    const int offset = 3;
+    const double threshold = 0.9 * m * (n_rows - 1 - offset);
+
+    const SwBandBounds bounds =
+            compute_band_bounds(n_rows, n_cols, offset, offset, m, g, threshold, false, n_rows - 1, n_cols - 1);
+
+    auto width_at = [&](int j) { return bounds.lo[j] > bounds.hi[j] ? 0 : bounds.hi[j] - bounds.lo[j] + 1; };
+
+    const int width_first = width_at(1);
+    const int width_last = width_at(n_cols - 1);
+    int widest = 0;
+    for (int j = 1; j != n_cols; ++j) {
+        widest = std::max(widest, width_at(j));
+    }
+
+    INFO("width at column 1 = " << width_first << ", width at last column = " << width_last
+                                 << ", widest = " << widest);
+    REQUIRE(widest > width_first);
+    REQUIRE(widest > width_last);
+}
+
+TEST_CASE("compute_band_bounds's score_threshold axis trims diagonals that can never qualify",
+          "[aligner][sw][band_bounds]")
+{
+    const int n_rows = 12;
+    const int n_cols = 12;
+    const double m = 2.0;
+    const int g = 1;
+
+    // Full unconstrained offset range, so only score_threshold shapes the result.
+    const int min_offset = std::numeric_limits<int>::min();
+    const int max_offset = std::numeric_limits<int>::max();
+
+    SECTION("a very high threshold that no diagonal can reach empties the whole band")
+    {
+        const double threshold = m * (n_rows + n_cols); // unreachable: exceeds the full-matrix max
+        const SwBandBounds bounds =
+                compute_band_bounds(n_rows, n_cols, min_offset, max_offset, m, g, threshold, false, n_rows - 1,
+                                    n_cols - 1);
+        for (int j = 1; j != n_cols; ++j) {
+            INFO("column " << j);
+            REQUIRE(bounds.lo[j] > bounds.hi[j]);
+        }
+    }
+
+    SECTION("a moderate threshold narrows the band relative to the unconstrained case")
+    {
+        const double threshold = m * (n_rows - 2); // reachable only near the main diagonal
+        const SwBandBounds narrow =
+                compute_band_bounds(n_rows, n_cols, min_offset, max_offset, m, g, threshold, false, n_rows - 1,
+                                    n_cols - 1);
+        const SwBandBounds wide =
+                compute_band_bounds(n_rows, n_cols, min_offset, max_offset, m, g,
+                                    -std::numeric_limits<double>::infinity(), false, n_rows - 1, n_cols - 1);
+
+        bool any_narrower = false;
+        for (int j = 1; j != n_cols; ++j) {
+            if (narrow.lo[j] > narrow.hi[j]) {
+                continue;
+            }
+            REQUIRE(wide.lo[j] <= wide.hi[j]);
+            REQUIRE(narrow.lo[j] >= wide.lo[j]);
+            REQUIRE(narrow.hi[j] <= wide.hi[j]);
+            if (narrow.lo[j] > wide.lo[j] || narrow.hi[j] < wide.hi[j]) {
+                any_narrower = true;
+            }
+        }
+        REQUIRE(any_narrower);
+    }
+}
+
+TEST_CASE("compute_band_bounds handles degenerate tiny matrices", "[aligner][sw][band_bounds]")
+{
+    SECTION("n_rows == 2, n_cols == 2")
+    {
+        const SwBandBounds bounds = compute_band_bounds(2, 2, std::numeric_limits<int>::min(),
+                                                        std::numeric_limits<int>::max(), 2.0, 1,
+                                                        -std::numeric_limits<double>::infinity(), false, 1, 1);
+        REQUIRE(bounds.lo[1] == 1);
+        REQUIRE(bounds.hi[1] == 1);
+    }
+
+    SECTION("min_offset > max_offset (already-empty input range) never crashes and yields an empty band")
+    {
+        const SwBandBounds bounds =
+                compute_band_bounds(6, 6, 5, -5, 2.0, 1, -std::numeric_limits<double>::infinity(), false, 5, 5);
+        for (int j = 1; j != 6; ++j) {
+            REQUIRE(bounds.lo[j] > bounds.hi[j]);
+        }
+    }
+}


### PR DESCRIPTION
Adds closed-form banded DP fill : sw_align now computes, from min_offset/max_offset/score_threshold/the substitution matrix alone, a column-indexed row range that provably bounds every cell that could belong to an admissible alignment, and restricts the DP fill to it instead of always computing the full matrix. Handles the prefix/suffix offset asymmetry between V/D-gene and J-gene alignment, and a forward+backward reachability bound needed because semi-global alignment never resets negative scores. Validated against brute-force enumeration (test_sw_band_bounds.cpp) and the full alignment regression suite; measured ~25–50x speedup on constrained-offset/tight-threshold configs (the common production case), with unconstrained cases unaffected.

Benchmark pipeline uses the "default" setting which are almost unbounded and thus won't show much improvement.

Looking at the "demo" output from the regression tests which adds loose bounds on V and J alignments and with limited number of sequences (some perf gains may be hidden by setup):

- V alignments are ~1.6x faster (0.413541s -> 0.245296s)
- J alignments are ~1.6x faster (0.0643577s -> 0396134s)

Docstring clarification: notes that best_only returns all alignments tied for the best score, not just one.